### PR TITLE
Updated link to couchdb 1.2.1

### DIFF
--- a/.openshift/action_hooks/pre_build
+++ b/.openshift/action_hooks/pre_build
@@ -17,7 +17,7 @@ wget http://ftp.mozilla.org/pub/mozilla.org/js/js185-1.0.0.tar.gz
 # get erlang
 wget http://www.erlang.org/download/otp_src_R15B03-1.tar.gz
 # get couchdb
-wget http://artfiles.org/apache.org/couchdb/1.2.1/apache-couchdb-1.2.1.tar.gz
+wget http://archive.apache.org/dist/couchdb/1.2.1/apache-couchdb-1.2.1.tar.gz
 # get ICU
 wget http://download.icu-project.org/files/icu4c/4.8.1.1/icu4c-4_8_1_1-src.tgz
 


### PR DESCRIPTION
Thanks for making this repo, I don't think I would have got couchdb running on OpenShift without it. I had to make a change to the CouchDB url.
